### PR TITLE
Added theme file

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,9 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="pine">#FF01796F</color>
+    <color name="blue_green">#FF99DDC8</color>
+    <color name="vermilion">#FFE6484D</color>
+    <color name="dark">#FF181A21</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="button_dark" parent="@style/Widget.MaterialComponents.Button">
+        <item name="android:backgroundTint">@color/pine</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,15 +2,18 @@
     <!-- Base application theme. -->
     <style name="Theme.QRcodequest" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorPrimary">@color/pine</item>
+        <item name="colorPrimaryVariant">@color/pine</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorSecondary">@color/blue_green</item>
+        <item name="colorSecondaryVariant">@color/blue_green</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@color/pine</item>
         <!-- Customize your theme here. -->
+        <item name="android:windowBackground">@color/dark</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="colorError">@color/vermilion</item>
     </style>
 </resources>


### PR DESCRIPTION
Adds a color palette of
 - @color/pine (primary)
 - @color/blue_green (secondary)
 - @color/vermilion (error)
 - @color/dark (background)
 
The theme sets:
 - windowBackgrounds to dark
 - error text to vermilion
 - regular text to white.

Additionally adds a dark button style (@style/button_dark) that uses pine as it's background.

![theme preview](https://user-images.githubusercontent.com/2926677/156963370-a3a7608e-d8e4-453e-a7df-74f616092b5d.png)
