### PR TITLE
remove comments field from QRCode to reduce coupling and make it more cohesive

### DIFF
--- a/app/src/main/java/com/qrcode_quest/entities/QRCode.java
+++ b/app/src/main/java/com/qrcode_quest/entities/QRCode.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 public class QRCode {
     @NonNull private final String hashCode;
     private final int score;
-    @NonNull private ArrayList<Comment> comments;
 
     /**
      * create a QRCode object from a RawQRCode; no comments will be attached to the
@@ -25,19 +24,16 @@ public class QRCode {
             throws UnsupportedEncodingException, NoSuchAlgorithmException {
         this.hashCode = rawCode.getQRHash();
         this.score = rawCode.getScore();
-        this.comments = new ArrayList<>();
     }
 
     /**
      * create a QRCode object
      * @param hashCode hash string of the actual qr code represented by this object
      * @param score score of the qr code
-     * @param comments comments made under the qr code by players
      */
-    public QRCode(@NonNull String hashCode, int score, @NonNull ArrayList<Comment> comments) {
+    public QRCode(@NonNull String hashCode, int score) {
         this.hashCode = hashCode;
         this.score = score;
-        this.comments = comments;
     }
 
     /**
@@ -54,21 +50,5 @@ public class QRCode {
      */
     public int getScore() {
         return score;
-    }
-
-    /**
-     * get a reference to the object's inner comment list
-     * @return the comment list under the qr code
-     */
-    public @NonNull ArrayList<Comment> getComments() {
-        return comments;
-    }
-
-    /**
-     * set the object's inner comment list as provided
-     * @param comments the comments to set under the qr code
-     */
-    public void setComments(@NonNull ArrayList<Comment> comments) {
-        this.comments = comments;
     }
 }

--- a/app/src/test/java/com/qrcode_quest/entities/QRCodeTest.java
+++ b/app/src/test/java/com/qrcode_quest/entities/QRCodeTest.java
@@ -20,11 +20,7 @@ public class QRCodeTest {
      * @return a mock QRCode object
      */
     private QRCode MockQRCode() throws UnsupportedEncodingException, NoSuchAlgorithmException {
-        QRCode code = new QRCode(MockRawQRCode());
-        String hash = code.getHashCode();
-        ArrayList<Comment> comments = code.getComments();
-        comments.add(new Comment("dog", "I bark", hash));
-        return code;
+        return new QRCode(MockRawQRCode());
     }
 
     @Test
@@ -35,27 +31,10 @@ public class QRCodeTest {
         // test the getters of mock QR code
         assertEquals(rawCode.getQRHash(), code.getHashCode());
         assertEquals(rawCode.getScore(), code.getScore());
-        assertEquals(1, code.getComments().size());
-
-        // change to a new comment list
-        ArrayList<Comment> newComments = new ArrayList<>();
-        newComments.add(new Comment("cat", "I purr", "hash12"));
-        newComments.add(new Comment("elephant", "I trumpet", "hash23"));
-        code.setComments(newComments);
-        assertEquals(2, code.getComments().size());
-        assertEquals("I trumpet", code.getComments().get(1).getContent());
-
-        // array list should be modified after modifying the array list get by getComments() interface
-        ArrayList<Comment> comments = code.getComments();
-        comments.add(new Comment("turtle", "I crawl", "hash34"));
-        comments.get(1).setQrHash("hash45");
-        assertEquals(3, code.getComments().size());
-        assertEquals("hash45", code.getComments().get(1).getQrHash());
 
         // test the other constructor
-        QRCode other = new QRCode("hash67", 44, new ArrayList<>());
+        QRCode other = new QRCode("hash67", 44);
         assertEquals("hash67", other.getHashCode());
         assertEquals(44, other.getScore());
-        assertEquals(0, other.getComments().size());
     }
 }


### PR DESCRIPTION
Comments list is likely only needed in the comment section, and having it as an attribute of QRCode will complicate database calls , so I removed the array list from QRCode class definition.