### PR TITLE
Feature getlocation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.4.0'
+    //testImplementation "androidx.arch.core:core-testing:2.1.0"
+    androidTestImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.4.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'org.mockito:mockito-android:4.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/androidTest/java/com/qrcode_quest/EspressoHelper.java
+++ b/app/src/androidTest/java/com/qrcode_quest/EspressoHelper.java
@@ -1,0 +1,27 @@
+package com.qrcode_quest;
+
+import android.view.View;
+
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.matcher.ViewMatchers;
+
+import org.hamcrest.Matcher;
+
+public class EspressoHelper {
+    public static ViewAction waitFor(long delay) {
+        return new ViewAction() {
+            @Override public Matcher<View> getConstraints() {
+                return ViewMatchers.isRoot();
+            }
+
+            @Override public String getDescription() {
+                return "wait for " + delay + "milliseconds";
+            }
+
+            @Override public void perform(UiController uiController, View view) {
+                uiController.loopMainThreadForAtLeast(delay);
+            }
+        };
+    }
+}

--- a/app/src/androidTest/java/com/qrcode_quest/MainActivityTest.java
+++ b/app/src/androidTest/java/com/qrcode_quest/MainActivityTest.java
@@ -21,7 +21,6 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.UiController;
-import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -67,12 +66,11 @@ public class MainActivityTest {
         // stackoverflow by gosr
         // url:https://stackoverflow.com/questions/61953249/how-to-access-activity-from-activityscenariorule
         ActivityScenario<MainActivity> scenario = rule.getScenario();
-        Log.d("START TEST", scenario.getState().name());
 
         // for more about how to use Espresso
         // see doc: https://developer.android.com/training/testing/espresso/basics
         onView(withId(R.id.navigation_leaderboard)).perform(click());
-        onView(isRoot()).perform(waitFor(3000));  // example of wait
+        onView(isRoot()).perform(EspressoHelper.waitFor(3000));  // example of wait
         onData(allOf(is(instanceOf(String.class)), is("This is home fragment")));
         onView(withId(R.id.playerlist_content_name))
                 .check(matches(withText(containsString("testPlayerName"))));
@@ -81,21 +79,5 @@ public class MainActivityTest {
             public void perform(MainActivity activity) {
             }
         });
-    }
-
-    public static ViewAction waitFor(long delay) {
-        return new ViewAction() {
-            @Override public Matcher<View> getConstraints() {
-                return ViewMatchers.isRoot();
-            }
-
-            @Override public String getDescription() {
-                return "wait for " + delay + "milliseconds";
-            }
-
-            @Override public void perform(UiController uiController, View view) {
-                uiController.loopMainThreadForAtLeast(delay);
-            }
-        };
     }
 }

--- a/app/src/androidTest/java/com/qrcode_quest/entities/GPSLocationLiveDataTest.java
+++ b/app/src/androidTest/java/com/qrcode_quest/entities/GPSLocationLiveDataTest.java
@@ -1,0 +1,134 @@
+package com.qrcode_quest.entities;
+
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.Manifest;
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationManager;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.testing.TestLifecycleOwner;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.rule.GrantPermissionRule;
+
+import com.qrcode_quest.MainActivity;
+import com.qrcode_quest.MockInstances;
+import com.qrcode_quest.MockLocationManager;
+import com.qrcode_quest.application.AppContainer;
+import com.qrcode_quest.application.QRCodeQuestApp;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+public class GPSLocationLiveDataTest {
+    final String GPSProvider = LocationManager.GPS_PROVIDER;
+    MutableLiveData<Location> actualLocation;
+
+    // StackOverflow, by donturner and Amin Keshavarzian
+    // url: https://stackoverflow.com/questions/50403128/how-to-grant-permissions-to-android-instrumented-tests
+    @Rule
+    public GrantPermissionRule fineLocRule = GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION);
+    @Rule
+    public GrantPermissionRule coarseLocRule = GrantPermissionRule.grant(Manifest.permission.ACCESS_COARSE_LOCATION);
+    public ActivityScenarioRule<MainActivity> rule;
+
+    @Rule
+    public ActivityScenarioRule<MainActivity> setupRule() {
+        // get the application object so we can provide mock db and other dependencies to it
+        QRCodeQuestApp app = ApplicationProvider.getApplicationContext();
+        AppContainer container = app.getContainer();
+
+        rule = new ActivityScenarioRule<>(MainActivity.class);
+        return rule;
+    }
+
+    private void setMockLocation(Geolocation l, long time) {
+        Location mockLocation = new Location(GPSProvider);
+        mockLocation.setLatitude(l.getLatitude());
+        mockLocation.setLongitude(l.getLongitude());
+        // timestamp of geolocation data
+        mockLocation.setTime(time);
+        mockLocation.setElapsedRealtimeNanos(time * 1000000);
+        mockLocation.setAccuracy((float) 0.1);  // we don't care about accuracy, just a placeholder
+        actualLocation.setValue(mockLocation);
+    }
+
+    @Before
+    public void setupLocationLiveData() {
+        actualLocation = new MutableLiveData<>();
+    }
+
+    @Test
+    public void testObserveLocation() {
+        ActivityScenario<MainActivity> scenario = rule.getScenario();
+        scenario.onActivity(new ActivityScenario.ActivityAction<MainActivity>() {
+            @Override
+            public void perform(MainActivity activity) {
+                Context context = activity.getApplicationContext();
+                TestLifecycleOwner lifecycleOwner = new TestLifecycleOwner();
+
+                LocationManager locationManager = MockLocationManager.createMockLocationManager(
+                        lifecycleOwner, actualLocation);
+                GPSLocationLiveData locationLiveData = new GPSLocationLiveData(
+                        context, locationManager);
+
+                Geolocation path[] = {
+                        new Geolocation(1.0, 1.0),
+                        new Geolocation(2.0, 2.0),
+                        new Geolocation(3.0, 3.0),
+                };
+                double results[] = {0.0, 0.0};
+                Observer<Geolocation> latObserver = new Observer<Geolocation>() {
+                    @Override
+                    public void onChanged(Geolocation location) {
+                        if (location != null)
+                            results[0] = location.getLatitude();
+                    }
+                };
+                Observer<Geolocation> lonObserver = new Observer<Geolocation>() {
+                    @Override
+                    public void onChanged(Geolocation location) {
+                        if (location != null)
+                            results[1] = location.getLongitude();
+                    }
+                };
+
+                locationLiveData.observe(lifecycleOwner, latObserver);
+                setMockLocation(path[0], 1);
+                assertEquals(1.0, results[0], 0.0);
+                assertEquals(0.0, results[1], 0.0);
+
+                locationLiveData.observe(lifecycleOwner, lonObserver);
+                setMockLocation(path[1], 10000);  // make sure at least 5000 ms has passed
+                assertEquals(2.0, results[0], 0.0);
+                assertEquals(2.0, results[1], 0.0);
+
+                locationLiveData.removeObserver(latObserver);
+                setMockLocation(path[2], 20000);
+                assertEquals(2.0, results[0], 0.0);
+                assertEquals(3.0, results[1], 0.0);
+
+                locationLiveData.removeObserver(lonObserver);
+                setMockLocation(path[1], 30000);
+                assertEquals(2.0, results[0], 0.0);
+                assertEquals(3.0, results[1], 0.0);
+
+                // ignore updates when time or distance is not satisfied
+            }
+        });
+    }
+}

--- a/app/src/androidTest/java/com/qrcode_quest/entities/GPSLocationLiveDataTest.java
+++ b/app/src/androidTest/java/com/qrcode_quest/entities/GPSLocationLiveDataTest.java
@@ -92,16 +92,16 @@ public class GPSLocationLiveDataTest {
                         new Geolocation(3.0, 3.0),
                 };
                 double results[] = {0.0, 0.0};
-                Observer<Geolocation> latObserver = new Observer<Geolocation>() {
+                Observer<Location> latObserver = new Observer<Location>() {
                     @Override
-                    public void onChanged(Geolocation location) {
+                    public void onChanged(Location location) {
                         if (location != null)
                             results[0] = location.getLatitude();
                     }
                 };
-                Observer<Geolocation> lonObserver = new Observer<Geolocation>() {
+                Observer<Location> lonObserver = new Observer<Location>() {
                     @Override
-                    public void onChanged(Geolocation location) {
+                    public void onChanged(Location location) {
                         if (location != null)
                             results[1] = location.getLongitude();
                     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.FLASHLIGHT"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/qrcode_quest/application/AppContainer.java
+++ b/app/src/main/java/com/qrcode_quest/application/AppContainer.java
@@ -4,6 +4,7 @@ import static com.qrcode_quest.Constants.SHARED_PREF_PATH;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.location.LocationManager;
 
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
@@ -18,6 +19,7 @@ public class AppContainer {
     private FirebaseFirestore db;
     private PhotoStorage storage;
     private SharedPreferences privateDevicePrefs;
+    private LocationManager locationManager;
 
     public AppContainer(QRCodeQuestApp app) {
         this.app = app;
@@ -59,5 +61,18 @@ public class AppContainer {
     public void setPrivateDevicePrefs(SharedPreferences privateDevicePrefs) {
         assert this.privateDevicePrefs == null;  // prevent accidentally set twice
         this.privateDevicePrefs = privateDevicePrefs;
+    }
+
+    public LocationManager getLocationManager() {
+        if (locationManager == null) {
+            locationManager = (LocationManager) app.getApplicationContext()
+                    .getSystemService(Context.LOCATION_SERVICE);
+        }
+        return locationManager;
+    }
+
+    public void setLocationManager(LocationManager locationManager) {
+        assert this.locationManager == null;
+        this.locationManager = locationManager;
     }
 }

--- a/app/src/main/java/com/qrcode_quest/entities/GPSLocationLiveData.java
+++ b/app/src/main/java/com/qrcode_quest/entities/GPSLocationLiveData.java
@@ -1,0 +1,107 @@
+package com.qrcode_quest.entities;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+import androidx.lifecycle.MutableLiveData;
+
+/**
+ * responsible for maintaining the user's current GPS location and updates it when requested
+ * access to this class should use isPermissionGranted() to check for location permission before
+ * observe() method calls
+ * this class is not responsible for obtaining location permission
+ *
+ * @author tianming
+ * @version 1.0
+ */
+public class GPSLocationLiveData extends MutableLiveData<Geolocation> {
+    /** used to check permission for GPS service */
+    @NonNull private final Context context;
+    /** the location manager provides location for the live data below */
+    @NonNull private final LocationManager locationManager;
+    /** the location listener registered in the LocationManager that updates the livedata */
+    private final LocationListener listener;
+    /** location won't update unless this minimum time has passed unit: millisecond */
+    private long minTimeMs;
+    /** location won't update unless the user moves this minimum distance unit: meter */
+    private float minDistanceM;
+
+    /**
+     * creates a GPSLocationLiveData; on creation the live data will contain a null reference to
+     * Geolocation, and location updates will only start after the first observer is attached.
+     * @param context the application context that contains permission information
+     * @param locationManager manages and provides updates to the geolocation
+     */
+    public GPSLocationLiveData(@NonNull Context context, @NonNull LocationManager locationManager) {
+        super(null);
+        this.context = context;
+        this.locationManager = locationManager;
+
+        // give some default values
+        minTimeMs = 5000;
+        minDistanceM = 10;
+
+        listener = location -> {
+            Geolocation newLocation = new Geolocation(
+                    location.getLatitude(), location.getLongitude());
+            GPSLocationLiveData.this.setValue(newLocation);
+        };
+    }
+
+    /**
+     * set the minimum time between updates
+     * @param minTimeMs minimum time between two updates in milliseconds
+     */
+    public void setMinTimeMs(long minTimeMs) {
+        this.minTimeMs = minTimeMs;
+    }
+
+    /**
+     * set the minimum distance between updates
+     * @param minDistanceM minimum distance between two updates in meters
+     */
+    public void setMinDistanceM(float minDistanceM) {
+        this.minDistanceM = minDistanceM;
+    }
+
+    /** @return true if the app is granted location service permission */
+    public boolean isPermissionGranted() {
+        return !(ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED
+                && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED);
+    }
+
+    /**
+     * called when an observer is attached, the livedata will start updating its location regularly
+     * by sending requests to GPS location tracker
+     */
+    @Override
+    protected void onActive() {
+        super.onActive();
+        if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED
+                && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
+
+            Log.d("GPS", "GPS location permission has not been obtained before observe() call!");
+        } else {
+            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER,
+                    minTimeMs, minDistanceM, listener);
+        }
+    }
+
+    /** called when the last active observer becomes inactive or is destroyed */
+    @Override
+    protected void onInactive() {
+        super.onInactive();
+        locationManager.removeUpdates(listener);
+    }
+}

--- a/app/src/main/java/com/qrcode_quest/entities/GPSLocationLiveData.java
+++ b/app/src/main/java/com/qrcode_quest/entities/GPSLocationLiveData.java
@@ -3,6 +3,7 @@ package com.qrcode_quest.entities;
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.util.Log;
@@ -21,7 +22,7 @@ import androidx.lifecycle.MutableLiveData;
  * @author tianming
  * @version 1.0
  */
-public class GPSLocationLiveData extends MutableLiveData<Geolocation> {
+public class GPSLocationLiveData extends MutableLiveData<Location> {
     /** used to check permission for GPS service */
     @NonNull private final Context context;
     /** the location manager provides location for the live data below */
@@ -49,9 +50,11 @@ public class GPSLocationLiveData extends MutableLiveData<Geolocation> {
         minDistanceM = 10;
 
         listener = location -> {
-            Geolocation newLocation = new Geolocation(
-                    location.getLatitude(), location.getLongitude());
-            GPSLocationLiveData.this.setValue(newLocation);
+//            Log.d("GPS_TIME", Long.toString(location.getTime()));
+//            Log.d("GPS_LON", Double.toString(location.getLongitude()));
+//            Log.d("GPS_LAT", Double.toString(location.getLatitude()));
+//            Log.d("GPS_ACC", Float.toString(location.getAccuracy()));
+            GPSLocationLiveData.this.setValue(location);
         };
     }
 

--- a/app/src/sharedTest/java/com/qrcode_quest/MockLocationManager.java
+++ b/app/src/sharedTest/java/com/qrcode_quest/MockLocationManager.java
@@ -1,0 +1,88 @@
+package com.qrcode_quest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Observer;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.HashMap;
+
+public class MockLocationManager {
+
+    public static class LocationRequestSetting {
+        public Location lastKnownLocation;
+        public String provider;
+        public long minTimeMs;
+        public float minDistanceM;
+        public LocationRequestSetting(String provider, long minTimeMs, float minDistanceM) {
+            this.provider = provider;
+            this.minTimeMs = minTimeMs;
+            this.minDistanceM = minDistanceM;
+            this.lastKnownLocation = null;
+        }
+    }
+
+    static public LocationManager createMockLocationManager(LifecycleOwner lifecycleOwner,
+                                                            LiveData<Location> actualLocation) {
+        LocationManager manager = mock(LocationManager.class);
+
+        HashMap<LocationListener, LocationRequestSetting> requests = new HashMap<>();
+
+        doAnswer(invocation -> {
+            String provider = invocation.getArgument(0);
+            Long time = invocation.getArgument(1);
+            Float distance = invocation.getArgument(2);
+            LocationListener listener = invocation.getArgument(3);
+
+            requests.put(listener, new LocationRequestSetting(provider, time, distance));
+
+            return null;
+        }).when(manager).requestLocationUpdates(anyString(), anyLong(), anyFloat(), any(LocationListener.class));
+
+        doAnswer(invocation -> {
+            LocationListener listenerToRemove = invocation.getArgument(0);
+            requests.remove(listenerToRemove);
+            return null;
+        }).when(manager).removeUpdates(any(LocationListener.class));
+
+        actualLocation.observe(lifecycleOwner, location -> {
+            // broadcast change to all location listeners
+            for(LocationListener listener: requests.keySet()) {
+                LocationRequestSetting setting = requests.get(listener);
+                assert setting != null;
+                String provider = location.getProvider();
+                if (provider.equals(setting.provider)) {
+                    Location lastKnownLocation = setting.lastKnownLocation;
+                    if (lastKnownLocation == null) {
+                        // first time set location
+                        setting.lastKnownLocation = location;
+                        listener.onLocationChanged(location);
+                    } else if (lastKnownLocation.distanceTo(location) >= setting.minDistanceM
+                            && (location.getTime() - lastKnownLocation.getTime()) >= setting.minTimeMs) {
+                        // update location
+                        setting.lastKnownLocation = location;
+                        listener.onLocationChanged(location);
+                    }
+                    // otherwise ignore the update
+                }
+            }
+        });
+
+        return manager;
+    }
+}


### PR DESCRIPTION
A new class GPSLocationLiveData for getting the location of user and corresponding test cases (did some simple tests in the simulator as well).

To start tracking the location, use something like the following in a fragment
```
QRCodeQuestApp app = (QRCodeQuestApp) requireActivity().getApplication();
AppContainer appContainer = app.getContainer();
GPSLocationLiveData liveData = new GPSLocationLiveData(app.getApplicationContext(),
        appContainer.getLocationManager());
liveData.observe(getViewLifecycleOwner(), new Observer<Location>() {
    @Override
    public void onChanged(Location geolocation) {
        if (geolocation != null) {
            // see link for how to use Location object: https://developer.android.com/reference/android/location/Location
        }
    }
});
```
GPS tracking will be disabled when all active observers are removed from the live data. 

We need to enable the location services permissions on the phone(Manifest.permission.ACCESS_FINE_LOCATION) in order for the location updates to start. The live data object has a isPermissionGranted() method for checking if the permission is enabled, and if not it should be handled separately