### PR TITLE
Fixed Delete Capture + small fixes

### DIFF
--- a/app/src/main/java/com/qrcode_quest/MainActivity.java
+++ b/app/src/main/java/com/qrcode_quest/MainActivity.java
@@ -16,9 +16,13 @@ import androidx.navigation.ui.NavigationUI;
 
 import com.qrcode_quest.application.AppContainer;
 import com.qrcode_quest.application.QRCodeQuestApp;
+import com.qrcode_quest.database.QRManager;
 import com.qrcode_quest.databinding.ActivityHomeBinding;
 import com.qrcode_quest.entities.QRShot;
+import com.qrcode_quest.entities.RawQRCode;
 
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
 
 public class MainActivity extends AppCompatActivity {

--- a/app/src/main/java/com/qrcode_quest/database/PlayerManager.java
+++ b/app/src/main/java/com/qrcode_quest/database/PlayerManager.java
@@ -46,7 +46,7 @@ public class PlayerManager extends DatabaseManager {
      * @param username The username to check
      */
     public void checkUserExists(String username, Listener<Boolean> listener) {
-        db.collection(Schema.COLLECTION_PLAYER_ACCOUNT)
+        getDb().collection(Schema.COLLECTION_PLAYER_ACCOUNT)
                 .document(Schema.getPlayerAccountDocumentName(username))
                 .get()
                 .addOnCompleteListener(task->{
@@ -70,7 +70,7 @@ public class PlayerManager extends DatabaseManager {
      * @param player The PlayerAccount to add
      */
     public void addPlayer(PlayerAccount player, Listener<Void> listener){
-        Task<Void> task = db.runTransaction(transaction -> {
+        Task<Void> task = getDb().runTransaction(transaction -> {
             final CollectionReference playersRef = db.collection(Schema.COLLECTION_PLAYER_ACCOUNT);
             final DocumentReference playerRef = playersRef.document(
                     Schema.getPlayerAccountDocumentName(player.getUsername()));
@@ -93,7 +93,7 @@ public class PlayerManager extends DatabaseManager {
      * @param deleted The state of deleted to switch to (true being deleted)
      */
     public void setDeletedPlayer(String username, boolean deleted, Listener<Void> listener){
-        Task<Void> task = db.runTransaction(transaction -> {
+        Task<Void> task = getDb().runTransaction(transaction -> {
             final CollectionReference playersRef = db.collection(Schema.COLLECTION_PLAYER_ACCOUNT);
             final DocumentReference playerRef = playersRef.document(
                     Schema.getPlayerAccountDocumentName(username));
@@ -113,8 +113,8 @@ public class PlayerManager extends DatabaseManager {
      * @param player The player data to update with
      */
     public void updatePlayer(PlayerAccount player, Listener<Void> listener){
-        Task<Void> task = db.runTransaction(transaction -> {
-            final CollectionReference playersRef = db.collection(Schema.COLLECTION_PLAYER_ACCOUNT);
+        Task<Void> task = getDb().runTransaction(transaction -> {
+            final CollectionReference playersRef = getDb().collection(Schema.COLLECTION_PLAYER_ACCOUNT);
             final DocumentReference playerRef = playersRef.document(
                     Schema.getPlayerAccountDocumentName(player.getUsername()));
 
@@ -133,7 +133,7 @@ public class PlayerManager extends DatabaseManager {
      * Fetches all the undeleted players from the database
      */
     public void getPlayerList(Listener<ArrayList<PlayerAccount>> listener){
-        Task<QuerySnapshot> task = db.collection(Schema.COLLECTION_PLAYER_ACCOUNT)
+        Task<QuerySnapshot> task = getDb().collection(Schema.COLLECTION_PLAYER_ACCOUNT)
                 .whereEqualTo(Schema.PLAYER_IS_DELETED, false)
                 .get();
         retrieveResultByTask(task, listener, new PlayerListRetriever());
@@ -147,7 +147,7 @@ public class PlayerManager extends DatabaseManager {
     public void validatePlayerSession(String deviceId, String username,
                                       Listener<Boolean> listener) {
 
-        db.collection(Schema.COLLECTION_AUTH)
+        getDb().collection(Schema.COLLECTION_AUTH)
                 .document(Schema.getAuthDocumentName(username, deviceId))
                 .get()
                 .addOnCompleteListener(task -> {
@@ -173,7 +173,7 @@ public class PlayerManager extends DatabaseManager {
         sessionMap.put(Schema.AUTH_PLAYER, username);
         sessionMap.put(Schema.AUTH_IS_PRIMARY_ACCOUNT, true);
 
-        Task<Void> task = db.collection(Schema.COLLECTION_AUTH)
+        Task<Void> task = getDb().collection(Schema.COLLECTION_AUTH)
                 .document(Schema.getAuthDocumentName(username, deviceId))
                 .set(sessionMap);
         retrieveResultByTask(task, listener, new VoidResultRetriever());

--- a/app/src/main/java/com/qrcode_quest/database/QRManager.java
+++ b/app/src/main/java/com/qrcode_quest/database/QRManager.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 /**
  * Interfaces to query and update QRShot objects in the Firestore database
  * @author tianming, jdumouch
- * @version 1.1
+ * @version 1.2
  * @see com.qrcode_quest.entities.QRCode
  * @see com.qrcode_quest.entities.QRShot
  */
@@ -298,6 +298,18 @@ public class QRManager extends DatabaseManager {
             }
         });
         retrieveResultByTask(task, onCompleteListener, new ManagerResult.VoidResultRetriever());
+    }
+
+    /**
+     * Removes a specific QRShot from the database
+     * @param owner The username of the owner of the QRShot
+     * @param qrHash The hash of the QRShot to remove
+     */
+    public void removeQRShot(String owner, String qrHash, Listener<Void> listener){
+        Task<Void> task = getDb().collection(Schema.COLLECTION_QRSHOT)
+                .document(Schema.getQRShotDocumentName(qrHash, owner))
+                .delete();
+        retrieveResultByTask(task, listener, new ManagerResult.VoidResultRetriever());
     }
 
     public void removeQRCode(String qrHash, Listener<Void> listener) {

--- a/app/src/main/java/com/qrcode_quest/ui/qr_view/QRViewFragment.java
+++ b/app/src/main/java/com/qrcode_quest/ui/qr_view/QRViewFragment.java
@@ -188,7 +188,8 @@ public class QRViewFragment extends Fragment {
      */
     private void deleteQR(){
         AppContainer container = ((QRCodeQuestApp) requireActivity().getApplication()).getContainer();
-        new QRManager(container.getDb(), container.getStorage()).removeQRCode(shotHash, result ->{
+        QRManager qrManager = new QRManager(container.getDb(), container.getStorage());
+        qrManager.removeQRShot(shotOwner, shotHash, result ->{
             if (!result.isSuccess()){
                 Log.e(CLASS_TAG, "Failed to delete QRShot.");
                 Toast.makeText(this.getActivity(), "Failed to delete.", Toast.LENGTH_LONG)

--- a/app/src/main/res/layout/fragment_qr_view.xml
+++ b/app/src/main/res/layout/fragment_qr_view.xml
@@ -264,7 +264,8 @@
                 android:text="@string/delete_qrcode"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/qrview_comments_button" />
+                app:layout_constraintTop_toBottomOf="@+id/qrview_comments_button"
+                android:visibility="gone"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
Delete Capture in QRView was deleting entire QRCodes rather than the specific shot.
QRManager.removeQRShot(...) was added to remedy this.
PlayerManger "db" calls were fixed to be getDb() calls (not sure if not using getDb() would have affected testing)
Fixed a bug in QRView where delete button was visible to non-privileged users (but still non-functioning) 